### PR TITLE
feat: 547

### DIFF
--- a/solution/547/number-of-provinces.go
+++ b/solution/547/number-of-provinces.go
@@ -1,0 +1,30 @@
+package solution
+
+func findCircleNum(isConnected [][]int) int {
+	seen := make([]int, len(isConnected))
+	provines := 0
+	for i := 0; i < len(isConnected); i++ {
+		if seen[i] == 1 {
+			continue
+		} else {
+			provines++
+			q := []int{i}
+			for len(q) > 0 {
+				size := len(q)
+				for j := 0; j < size; j++ {
+					if seen[q[j]] == 0 {
+						seen[q[j]] = 1
+						for idx, p := range isConnected[q[j]] {
+							if seen[idx] == 0 && p == 1 {
+								q = append(q, idx)
+							}
+						}
+					}
+				}
+				q = q[size:]
+			}
+		}
+	}
+
+	return provines
+}


### PR DESCRIPTION
# Intuition
- for each provine in the isConnected provines, count number of provines we did not seen.
- As 2 connected provines is treated as 1 provine, mark the seen provines as one provine.
<!-- Describe your first thoughts on how to solve this problem. -->

# Approach
<!-- Describe your approach to solving the problem. -->

# Complexity
- Time complexity:
- O(n^2)
<!-- Add your time complexity here, e.g. $$O(n)$$ -->

- Space complexity:
- O(n)
<!-- Add your space complexity here, e.g. $$O(n)$$ -->

# Code
```go
func findCircleNum(isConnected [][]int) int {
    seen := make([]int, len(isConnected))
    provines := 0
    for i:=0;i<len(isConnected);i++ {
        if seen[i] == 1 {
            continue
        } else {
            provines++
            q := []int{i}
            for len(q) > 0 {
                size := len(q)
                for j:=0;j<size;j++ {
                    if seen[q[j]] == 0 {
                        seen[q[j]] = 1
                        for idx,p := range isConnected[q[j]] {
                            if seen[idx] == 0 && p == 1 {
                                q = append(q, idx)
                            }
                        }
                    }
                }
                q = q[size:]
            }
        }
    }
    
    return provines
}
```